### PR TITLE
feat: use WordPress featured image as blog post og:image

### DIFF
--- a/src/pages/blog/[year]/[slug].astro
+++ b/src/pages/blog/[year]/[slug].astro
@@ -35,7 +35,17 @@ const { content: processedContent, embeds } = processContentWithPrivacy(post.con
 const metadata = {
   title: post.title.rendered,
   description: post.excerpt.rendered.replace(/<[^>]*>/g, '').substring(0, 160),
-  // Skip OG images to avoid remote dimension fetching issues during build
+  ...(featuredImage && {
+    openGraph: {
+      images: [
+        {
+          url: featuredImage.url,
+          width: featuredImage.width,
+          height: featuredImage.height,
+        },
+      ],
+    },
+  }),
 };
 ---
 

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -82,6 +82,18 @@ export const adaptOpenGraphImages = async (
           isUnpicCompatible(resolvedImage)
         ) {
           _image = (await unpicOptimizer(resolvedImage, [defaultWidth], defaultWidth, defaultHeight, 'jpg'))[0];
+        } else if (
+          typeof resolvedImage === 'string' &&
+          (resolvedImage.startsWith('http://') || resolvedImage.startsWith('https://'))
+        ) {
+          // External image without a recognized CDN (e.g. WordPress).
+          // Pass it through as-is; og:image is consumed remotely by crawlers,
+          // and the author-provided width/height are authoritative.
+          return {
+            url: resolvedImage,
+            width: image.width,
+            height: image.height,
+          };
         } else if (resolvedImage) {
           const dimensions =
             typeof resolvedImage !== 'string' && resolvedImage?.width <= defaultWidth


### PR DESCRIPTION
Pass through external og:image URLs without running them through the
Astro asset optimizer, which requires the domain to be registered and
fetches dimensions remotely at build time. The featured image's width
and height from the WordPress REST API are authoritative, so og:image
meta tags now point directly at the WordPress media URL.